### PR TITLE
fix: 🐛 去除默认赋值的favicon

### DIFF
--- a/vue-wechat-title.js
+++ b/vue-wechat-title.js
@@ -9,8 +9,8 @@
       if (/iphone|ipad|ipod/.test(mobile)) {
         var iframe = document.createElement('iframe')
         iframe.style.display = 'none'
-        // 替换成站标favicon路径或者任意存在的较小的图片即可
-        iframe.setAttribute('src', img || 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7')
+        // 替换成站标favicon路径或者任意存在的较小的图片即可，支付宝小程序引用原先base64会有安全警告
+        img && iframe.setAttribute('src', img)
         var iframeCallback = function () {
           setTimeout(function () {
             iframe.removeEventListener('load', iframeCallback)


### PR DESCRIPTION
发现在支付宝小程序的webview组件H5上使用[vue-wechat-title](https://github.com/deboyblog/vue-wechat-title) ，其中如果执行这句
```js
iframe.setAttribute('src', img || 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7')
```
支付宝小程序会有安全警告，故增加条件判断，没有传img参数就不执行。